### PR TITLE
Zoosk modifications

### DIFF
--- a/mod_realdoc.c
+++ b/mod_realdoc.c
@@ -147,7 +147,12 @@ static int realdoc_hook_handler(request_rec *r) {
 
     if (*last_saved_real_time < (current_request_time - realdoc_conf->realpath_every)) {
         if (NULL == realpath(core_conf->ap_document_root, last_saved_real_docroot)) {
-            AP_LOG_ERROR(r, "Error from realpath: %d. Original docroot: %s", errno, core_conf->ap_document_root);
+            if (errno == ENOENT) {
+                // Don't log an error for "No such file or directory"
+                AP_LOG_DEBUG(r, "Error from realpath: %d. Original docroot: %s", errno, core_conf->ap_document_root);
+            } else {
+                AP_LOG_ERROR(r, "Error from realpath: %d. Original docroot: %s", errno, core_conf->ap_document_root);
+            }
             return DECLINED;
         }
 

--- a/mod_realdoc.c
+++ b/mod_realdoc.c
@@ -161,7 +161,7 @@ static int realdoc_hook_handler(request_rec *r) {
 }
 
 void realdoc_register_hook(apr_pool_t *p) {
-    ap_hook_post_read_request(realdoc_hook_handler, NULL, NULL, APR_HOOK_REALLY_FIRST);
+    ap_hook_translate_name(realdoc_hook_handler, NULL, NULL, APR_HOOK_FIRST+1);
 }
 
 AP_MODULE_DECLARE_DATA module realdoc_module = {


### PR DESCRIPTION
The most significant of these changes is in where during the apache processing timeline this resolution happens.  I think that where I've placed it is more appropriate.  It allows mod_rewrite and other such rules to work as expected.  The previous location caused a number of problems.

I also downgraded the severity of file not found errors, since we get a number of incoming requests that indeed do not have a file.  That's fine, and those will be handled with 404s or appropriate responses.
