### PR TITLE
Thread safety

### DIFF
--- a/mod_realdoc.c
+++ b/mod_realdoc.c
@@ -189,17 +189,20 @@ static apr_status_t realdoc_restore_docroot(void *data) {
 }
 
 static int realdoc_hook_handler(request_rec *r) {
-    core_server_config *core_conf;
-    realdoc_config_struct *realdoc_conf;
+    core_server_config *core_conf = ap_get_module_config(r->server->module_config, &core_module);
+    realdoc_config_struct *realdoc_conf = (realdoc_config_struct *) ap_get_module_config(r->server->module_config, &realdoc_module);
+
+    // Skip if RealpathEvery is not configured
+    if (!realdoc_conf->realpath_every) {
+        return DECLINED;
+    }
+
     realdoc_request_save_struct *save;
     char *last_saved_real_docroot;
     apr_time_t *last_saved_real_time;
     apr_time_t current_request_time;
     const char *last_saved_docroot_key = apr_psprintf(r->pool, "%s:%u:realdoc_saved_docroot", ap_get_server_name(r), ap_get_server_port(r));
     const char *last_saved_time_key = apr_psprintf(r->pool, "%s:%u:realdoc_saved_time", ap_get_server_name(r), ap_get_server_port(r));
-
-    core_conf = ap_get_module_config(r->server->module_config, &core_module);
-    realdoc_conf = (realdoc_config_struct *) ap_get_module_config(r->server->module_config, &realdoc_module);
 
     apr_pool_userdata_get((void **) &last_saved_real_docroot, last_saved_docroot_key, r->server->process->pool);
 


### PR DESCRIPTION
## Description

Looking at #4 I wanted to take a stab at adding thread safety, because I didn't see a reason why it should not be possible to get it working.

## Context / Why are we making this change?

When using Apache with mod_proxy for PHP-FPM or any other scripting language, threaded MPMs are a good fit. This pull request adds thread safety.

## Testing and QA Plan

Reproducing the existing issues way easy enough (simply by using ab with high enough request concurrency). The code changes have been reviewed carefully and tested with the same scripts that triggered the errors before.

## Impact

For any threaded and non-threaded MPM, there is an overhead because of the newly introduced mutex. In our test, it was still possible to achieve 16k req/s even with a prefork MPM on a single workstation.

The added thread safety and broader deployment range is worth it IMHO.